### PR TITLE
Fix map filter button focus state

### DIFF
--- a/src/components/shared/search/SearchHeader/SearchHeader.tsx
+++ b/src/components/shared/search/SearchHeader/SearchHeader.tsx
@@ -190,7 +190,10 @@ export default function SearchHeader({
           <button
             type="button"
             className={`${styles.filterButton} ${styles.filterButtonAction}`}
-            onClick={() => setIsFilterOpen(true)}
+            onClick={(event) => {
+              setIsFilterOpen(true);
+              event.currentTarget.blur();
+            }}
           >
             フィルター
           </button>


### PR DESCRIPTION
## Summary
- blur the map search filter trigger after opening to avoid a lingering focus state

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ed1fe8f6883288bef51442db2a7c1)