### PR TITLE
Fix ranking title visibility on home page

### DIFF
--- a/src/app/home/styles.css
+++ b/src/app/home/styles.css
@@ -134,9 +134,9 @@
   background-color: #007AFF; /* 青色 (ブルー) */
 }
 
-.main{ 
+.main{
   background-color: var(--color-bg-primary);
-  color: var(--color-bg-primary);
+  color: var(--color-text-primary);
   padding-bottom:80px;
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
## Summary
- ensure the home page main section uses the primary text color so the ranking title is visible

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ed1483adc8328b158fb25556bea94)