### PR TITLE
Add featured heading to home page

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -156,6 +156,10 @@ useEffect(() => {
         </motion.div>
       </div>
     </div>
+
+        <div className="featured-heading">
+          <h1>おすすめ企画</h1>
+        </div>
         <Swiper
             loop={true}
             /*autoplay={{

--- a/src/app/home/styles.css
+++ b/src/app/home/styles.css
@@ -42,6 +42,21 @@
   overflow:  hidden;
 }
 
+.featured-heading {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 1.5rem 0 1rem;
+}
+
+.featured-heading h1 {
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  font-weight: 800;
+  color: var(--svg-color, #000000);
+  text-align: center;
+}
+
 
 .swiper-wrapper {
   align-items: center;


### PR DESCRIPTION
## Summary
- add a centered “おすすめ企画” heading above the home page carousel
- style the heading for large, responsive text

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ed171b43483288a7654b1bc23205a)