### PR TITLE
Ensure map filter reset button stays visible above bottom bar

### DIFF
--- a/src/components/shared/search/FilterSheet/FilterSheet.module.css
+++ b/src/components/shared/search/FilterSheet/FilterSheet.module.css
@@ -154,6 +154,15 @@
   cursor: pointer;
 }
 
+.resetButtonContainer {
+  position: sticky;
+  bottom: 0;
+  padding: 12px 0 calc(12px + env(safe-area-inset-bottom, 12px));
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95) 0%, #fff 70%);
+  border-top: 1px solid #e5e7eb;
+  box-shadow: 0 -8px 16px rgba(0, 0, 0, 0.05);
+}
+
 @keyframes slideDown {
   from {
     transform: translateY(-100%);

--- a/src/components/shared/search/FilterSheet/FilterSheet.module.css
+++ b/src/components/shared/search/FilterSheet/FilterSheet.module.css
@@ -70,6 +70,7 @@
   max-height: calc(100vh - 80px);
   overflow-y: auto;
   padding: 16px;
+  padding-bottom: calc(16px + env(safe-area-inset-bottom, 0) + 80px);
 }
 
 .section {
@@ -152,15 +153,6 @@
   background: white;
   font-weight: 600;
   cursor: pointer;
-}
-
-.resetButtonContainer {
-  position: sticky;
-  bottom: 0;
-  padding: 12px 0 calc(12px + env(safe-area-inset-bottom, 12px));
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95) 0%, #fff 70%);
-  border-top: 1px solid #e5e7eb;
-  box-shadow: 0 -8px 16px rgba(0, 0, 0, 0.05);
 }
 
 @keyframes slideDown {

--- a/src/components/shared/search/FilterSheet/FilterSheet.tsx
+++ b/src/components/shared/search/FilterSheet/FilterSheet.tsx
@@ -132,11 +132,9 @@ const FilterSheet: React.FC<FilterSheetProps> = ({
             </div>
           </section>
 
-          <div className={styles.resetButtonContainer}>
-            <button type="button" className={styles.resetButton} onClick={onReset}>
-              すべてリセット
-            </button>
-          </div>
+          <button type="button" className={styles.resetButton} onClick={onReset}>
+            すべてリセット
+          </button>
         </div>
       </section>
     </div>

--- a/src/components/shared/search/FilterSheet/FilterSheet.tsx
+++ b/src/components/shared/search/FilterSheet/FilterSheet.tsx
@@ -132,9 +132,11 @@ const FilterSheet: React.FC<FilterSheetProps> = ({
             </div>
           </section>
 
-          <button type="button" className={styles.resetButton} onClick={onReset}>
-            すべてリセット
-          </button>
+          <div className={styles.resetButtonContainer}>
+            <button type="button" className={styles.resetButton} onClick={onReset}>
+              すべてリセット
+            </button>
+          </div>
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- wrap the filter reset action in a sticky container to keep it within view on the filter sheet
- add padding, gradient background, and safe-area spacing so the reset control stays above the bottom bar

## Testing
- npm run lint (fails: existing parsing errors in project)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920edfc70ac832898fd66572ea5831d)